### PR TITLE
Product Details UI Issues

### DIFF
--- a/saiyan-storefront/src/app/layout.tsx
+++ b/saiyan-storefront/src/app/layout.tsx
@@ -18,7 +18,7 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <body>
+      <body className="bg-slate-300">
         <Providers>
           <main className="relative">{children}</main>
         </Providers>

--- a/saiyan-storefront/src/app/layout.tsx
+++ b/saiyan-storefront/src/app/layout.tsx
@@ -17,7 +17,7 @@ export default function RootLayout({
   children: React.ReactNode
 }) {
   return (
-    <html lang="en" data-theme="forest">
+    <html lang="en">
       <body>
         <Providers>
           <main className="relative">{children}</main>

--- a/saiyan-storefront/src/modules/cart/templates/items.tsx
+++ b/saiyan-storefront/src/modules/cart/templates/items.tsx
@@ -11,7 +11,7 @@ const ItemsTemplate = ({ items, region }: ItemsTemplateProps) => {
   return (
     <div>
       <div className="border-b border-gray-200 pb-3 flex items-center">
-        <h1 className="text-xl-semi">Shopping Bag</h1>
+        <h1 className="text-xl-semi">Shopping Cart</h1>
       </div>
       <div className="grid grid-cols-1 gap-y-8 py-8">
         {items && region

--- a/saiyan-storefront/src/modules/checkout/templates/index.tsx
+++ b/saiyan-storefront/src/modules/checkout/templates/index.tsx
@@ -25,7 +25,7 @@ const CheckoutTemplate = () => {
               </>
             </Link>
             <Link href="/" className="text-xl-semi">
-              ACME
+              Saiyan Prints
             </Link>
             <div className="flex-1 basis-0" />
           </nav>

--- a/saiyan-storefront/src/modules/products/components/related-products/index.tsx
+++ b/saiyan-storefront/src/modules/products/components/related-products/index.tsx
@@ -58,9 +58,9 @@ const RelatedProducts = ({ product }: RelatedProductsProps) => {
         </p>
       </div>
 
-      <ul className="grid grid-cols-2 small:grid-cols-3 medium:grid-cols-4 gap-x-4 gap-y-8t">
+      <ul className="grid grid-cols-1 xsmall:grid-cols-1 sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 text-slate-900">
         {previews.map((p) => (
-          <li key={p.id}>
+          <li key={p.id} className="m-auto">
             <ProductPreview {...p} />
           </li>
         ))}

--- a/saiyan-storefront/src/modules/skeletons/templates/skeleton-product-page/index.tsx
+++ b/saiyan-storefront/src/modules/skeletons/templates/skeleton-product-page/index.tsx
@@ -5,7 +5,7 @@ import SkeletonProductTabs from "@modules/skeletons/components/skeleton-product-
 const SkeletonProductPage = () => {
   return (
     <div>
-      <div className="content-container flex flex-col small:flex-row small:items-start py-6 relative">
+      <div className="content-container bg-slate-300 flex flex-col small:flex-row small:items-start py-6 relative">
         <div className="flex flex-col gap-y-8 w-full">
           <div className="flex items-start relative">
             <div className="hidden small:flex flex-col gap-y-4 sticky top-20">


### PR DESCRIPTION
Fixes #9

## Description
When you would click on the product details page, the skeleton was set with a dark background, and would throw off the ui when switching from the main page to the product details.

It would cause a flash of black with the skeleton instead of the themed background.

## Related Issues
Related products grid is a bit messed up as well. Since it tied in with the product details the fix for the related products grid is with this PR.

## Additional Context

